### PR TITLE
Support Joi v16 + descriptive messages

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -1,9 +1,9 @@
-const path = require('path');
+const Joi = require('@hapi/joi');
 
-/* eslint-disable import/no-dynamic-require */
-const Any = require(path.join(path.dirname(require.resolve('@hapi/joi')), 'types/any/index.js'));
-const Language = require(path.join(path.dirname(require.resolve('@hapi/joi')), 'language.js'));
-/* eslint-enable */
+// pluralize
+const p = (word, num) => num === 1
+  ? word
+  : `${word}s`;
 
 const defaultOptions = {
   min: 8,
@@ -15,97 +15,96 @@ const defaultOptions = {
   requirementCount: 4,
 };
 
-const PasswordComplexity = class extends Any {
-  constructor(options) {
-    super();
-    this._type = 'string';
-    this._invalids.add('');
+module.exports = (options = defaultOptions) => {
+  const extendWithClosure = Joi.extend({
+    type: 'passwordComplexity',
+    base: Joi.string(),
+    messages: {
+      'passwordComplexity.tooShort':
+        `"{{#label}}" should be at least ${
+          options.min
+        } ${p('character', options.min)} long`,
+      'passwordComplexity.tooLong':
+        `"{{#label}}" should not be longer than ${
+          options.max
+        } ${p('character', options.max)}`,
+      'passwordComplexity.lowercase':
+        `"{{#label}}" should contain at least ${
+          options.lowerCase
+        } lowercased ${p('letter', options.lowerCase)}`,
+      'passwordComplexity.uppercase':
+        `"{{#label}}" should contain at least ${
+          options.upperCase
+        } uppercased ${p('letter', options.upperCase)}`,
+      'passwordComplexity.numeric':
+        `"{{#label}}" should contain at least ${
+          options.numeric
+        } ${p('number', options.numeric)}`,
+      'passwordComplexity.symbol':
+        `"{{#label}}" should contain at least ${
+          options.symbol
+        } ${p('symbol', options.symbol)}`,
+      'passwordComplexity.requirementCount':
+        `"{{#label}}" must meet at least ${
+          options.requirementCount
+        } of the complexity requirements`
+    },
+    validate(value, helpers) {
+      const errors = [];
 
-    this._options = options || defaultOptions;
-  }
+      if (typeof value === 'string') {
+        const lowercaseCount = (value.match(/[a-z]/g) || []).length;
+        const upperCaseCount = (value.match(/[A-Z]/g) || []).length;
+        const numericCount = (value.match(/[0-9]/g) || []).length;
+        const symbolCount = (value.match(/[^a-zA-Z0-9]/g) || []).length;
 
-  clone() {
-    const clone = super.clone();
+        const meetsMin = options.min && value.length >= options.min;
+        const meetsMax = options.max && value.length <= options.max;
 
-    clone._options = {};
+        const meetsLowercase = lowercaseCount >= options.lowerCase;
+        const meetsUppercase = upperCaseCount >= options.upperCase;
+        const meetsNumeric = numericCount >= options.numeric;
+        const meetsSymbol = symbolCount >= options.symbol;
 
-    clone._options.min = this._options.min;
-    clone._options.max = this._options.max;
-    clone._options.lowerCase = this._options.lowerCase;
-    clone._options.upperCase = this._options.upperCase;
-    clone._options.numeric = this._options.numeric;
-    clone._options.symbol = this._options.symbol;
-    clone._options.requirementCount = this._options.requirementCount;
+        const maxRequirement = (options.lowerCase > 0) + (options.upperCase > 0) +
+          (options.numeric > 0) + (options.symbol > 0);
 
-    return clone;
-  }
+        const requirementCount = Math.min(
+          Math.max(parseInt(options.requirementCount, 10) || maxRequirement, 1),
+          maxRequirement,
+        );
 
-  _base(value, state, options) {
-    const errors = [];
+        const requirementErrors = [];
 
-    if (typeof value === 'string') {
-      const lowercaseCount = (value.match(/[a-z]/g) || []).length;
-      const upperCaseCount = (value.match(/[A-Z]/g) || []).length;
-      const numericCount = (value.match(/[0-9]/g) || []).length;
-      const symbolCount = (value.match(/[^a-zA-Z0-9]/g) || []).length;
+        if (!meetsMin) errors.push(helpers.error('passwordComplexity.tooShort', { value }));
+        if (!meetsMax) errors.push(helpers.error('passwordComplexity.tooLong', { value }));
+        if (!meetsLowercase) {
+          requirementErrors.push(helpers.error('passwordComplexity.lowercase', { value }));
+        }
+        if (!meetsUppercase) {
+          requirementErrors.push(helpers.error('passwordComplexity.uppercase', { value }));
+        }
+        if (!meetsNumeric) {
+          requirementErrors.push(helpers.error('passwordComplexity.numeric', { value }));
+        }
+        if (!meetsSymbol) {
+          requirementErrors.push(helpers.error('passwordComplexity.symbol', { value }));
+        }
 
-      const meetsMin = this._options.min && value.length >= this._options.min;
-      const meetsMax = this._options.max && value.length <= this._options.max;
-
-      const meetsLowercase = lowercaseCount >= this._options.lowerCase;
-      const meetsUppercase = upperCaseCount >= this._options.upperCase;
-      const meetsNumeric = numericCount >= this._options.numeric;
-      const meetsSymbol = symbolCount >= this._options.symbol;
-
-      const maxRequirement = (this._options.lowerCase > 0) + (this._options.upperCase > 0) +
-        (this._options.numeric > 0) + (this._options.symbol > 0);
-
-      const requirementCount = Math.min(
-        Math.max(parseInt(this._options.requirementCount, 10) || maxRequirement, 1),
-        maxRequirement,
-      );
-
-      const requirementErrors = [];
-
-      if (!meetsMin) errors.push(this.createError('passwordComplexity.tooShort', { value }, state, options));
-      if (!meetsMax) errors.push(this.createError('passwordComplexity.tooLong', { value }, state, options));
-      if (!meetsLowercase) {
-        requirementErrors.push(this.createError('passwordComplexity.lowercase', { value }, state, options));
-      }
-      if (!meetsUppercase) {
-        requirementErrors.push(this.createError('passwordComplexity.uppercase', { value }, state, options));
-      }
-      if (!meetsNumeric) {
-        requirementErrors.push(this.createError('passwordComplexity.numeric', { value }, state, options));
-      }
-      if (!meetsSymbol) {
-        requirementErrors.push(this.createError('passwordComplexity.symbol', { value }, state, options));
-      }
-
-      if (maxRequirement - requirementErrors.length < requirementCount) {
-        errors.push(...requirementErrors);
-        if (requirementCount < maxRequirement) {
-          errors.push(this.createError('passwordComplexity.requirementCount', { value }, state, options));
+        if (maxRequirement - requirementErrors.length < requirementCount) {
+          errors.push(...requirementErrors);
+          if (requirementCount < maxRequirement) {
+            errors.push(helpers.error('passwordComplexity.requirementCount', { value }));
+          }
         }
       }
-    }
 
-    return {
-      value,
-      errors: errors.length ? errors : null,
-    };
-  }
+      return {
+        value,
+        errors: errors.length ? errors : null,
+      };
+    },
+  });
+
+  return extendWithClosure.passwordComplexity();
 };
-
-Language.errors.passwordComplexity = {
-  base: 'must meet password complexity requirements',
-  tooShort: 'is too short',
-  tooLong: 'is too long',
-  lowercase: 'doesn\'t contain the required lowercase characters',
-  uppercase: 'doesn\'t contain the required uppercase characters',
-  numeric: 'doesn\'t contain the required numeric characters',
-  symbol: 'doesn\'t contain the required symbols',
-  requirementCount: 'must meet enough of the complexity requirements',
-};
-
-module.exports = PasswordComplexity;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "joi-password-complexity",
-  "version": "3.1.0",
+  "version": "4.0.0",
   "description": "Joi validation for password complexity requirements.",
   "main": "lib/index.js",
   "scripts": {
@@ -38,6 +38,6 @@
     "verbose": true
   },
   "dependencies": {
-    "@hapi/joi": "^15.1.1"
+    "@hapi/joi": "^16.1.7"
   }
 }

--- a/test/password.test.js
+++ b/test/password.test.js
@@ -1,76 +1,77 @@
 const Joi = require('@hapi/joi');
 
-const PasswordComplexity = require('../lib/index');
+const passwordComplexity = require('../lib/index');
 
 describe('JoiPasswordComplexity', () => {
   it('should reject a password that is too short', () => {
     const password = '123';
 
-    const result = Joi.validate(password, new PasswordComplexity());
+    const result = passwordComplexity().validate(password);
     const errors = result.error.details.filter((e) => e.type === 'passwordComplexity.tooShort');
     expect(errors.length).toBe(1);
-    expect(errors[0].message).toBe('"value" is too short');
+    expect(errors[0].message).toBe('"value" should be at least 8 characters long');
   });
   it('should reject a password that is too long', () => {
     const password = '123456791234567912345679123';
 
-    const result = Joi.validate(password, new PasswordComplexity());
+    const result = passwordComplexity().validate(password);
     const errors = result.error.details.filter((e) => e.type === 'passwordComplexity.tooLong');
 
     expect(errors.length).toBe(1);
-    expect(errors[0].message).toBe('"value" is too long');
+    expect(errors[0].message).toBe('"value" should not be longer than 26 characters');
   });
 
   it('should reject a password that doesn\'t meet the required lowercase count', () => {
     const password = 'ABCDEFG';
 
-    const result = Joi.validate(password, new PasswordComplexity());
+    const result = passwordComplexity().validate(password);
     const errors = result.error.details.filter((e) => e.type === 'passwordComplexity.lowercase');
 
     expect(errors.length).toBe(1);
-    expect(errors[0].message).toBe('"value" doesn\'t contain the required lowercase characters');
+    expect(errors[0].message).toBe('"value" should contain at least 1 lowercased letter');
   });
 
   it('should reject a password that doesn\'t meet the required uppercase count', () => {
     const password = 'abcdefg';
 
-    const result = Joi.validate(password, new PasswordComplexity());
+    const result = passwordComplexity().validate(password);
     const errors = result.error.details.filter((e) => e.type === 'passwordComplexity.uppercase');
 
     expect(errors.length).toBe(1);
-    expect(errors[0].message).toBe('"value" doesn\'t contain the required uppercase characters');
+    expect(errors[0].message).toBe('"value" should contain at least 1 uppercased letter');
   });
 
   it('should reject a password that doesn\'t meet the required numeric count', () => {
     const password = 'ABCDEFG';
 
-    const result = Joi.validate(password, new PasswordComplexity());
+    const result = passwordComplexity().validate(password);
     const errors = result.error.details.filter((e) => e.type === 'passwordComplexity.numeric');
 
     expect(errors.length).toBe(1);
-    expect(errors[0].message).toBe('"value" doesn\'t contain the required numeric characters');
+    expect(errors[0].message).toBe('"value" should contain at least 1 number');
   });
 
   it('should reject a password that doesn\'t meet the required symbol count', () => {
     const password = 'ABCDEFG';
 
-    const result = Joi.validate(password, new PasswordComplexity());
+    const result = passwordComplexity().validate(password);
     const errors = result.error.details.filter((e) => e.type === 'passwordComplexity.symbol');
 
     expect(errors.length).toBe(1);
-    expect(errors[0].message).toBe('"value" doesn\'t contain the required symbols');
+    expect(errors[0].message).toBe('"value" should contain at least 1 symbol');
   });
 
   it('should accept a valid password with default options', () => {
     const password = 'abCD12#$';
-    const result = Joi.validate(password, new PasswordComplexity());
+    const result = passwordComplexity().validate(password);
 
-    expect(result.error).toBeNull();
+    expect(result.error).toBeUndefined();
   });
 
   it('should accept a password that meets a requirement count', () => {
     const password = 'Password123';
-    const result = Joi.validate(password, new PasswordComplexity({
+
+    const result = passwordComplexity({
       min: 8,
       max: 30,
       lowerCase: 1,
@@ -78,14 +79,14 @@ describe('JoiPasswordComplexity', () => {
       numeric: 1,
       symbol: 1,
       requirementCount: 3,
-    }));
+    }).validate(password);
 
-    expect(result.error).toBeNull();
+    expect(result.error).toBeUndefined();
   });
 
   it('should accept a password that has no requirement count', () => {
     const password = 'Password123';
-    const result = Joi.validate(password, new PasswordComplexity({
+    const result = passwordComplexity({
       min: 8,
       max: 30,
       lowerCase: 1,
@@ -93,14 +94,14 @@ describe('JoiPasswordComplexity', () => {
       numeric: 1,
       symbol: 0,
       requirementCount: 0,
-    }));
+    }).validate(password);
 
-    expect(result.error).toBeNull();
+    expect(result.error).toBeUndefined();
   });
 
   it('should reject a password that fails other requirements without a requirement count', () => {
     const password = 'Password';
-    const result = Joi.validate(password, new PasswordComplexity({
+    const result = passwordComplexity({
       min: 8,
       max: 30,
       lowerCase: 1,
@@ -108,17 +109,17 @@ describe('JoiPasswordComplexity', () => {
       numeric: 1,
       symbol: 0,
       requirementCount: 0,
-    }));
+    }).validate(password);
 
     const errors = result.error.details.filter((e) => e.type === 'passwordComplexity.numeric');
 
     expect(errors.length).toBe(1);
-    expect(errors[0].message).toBe('"value" doesn\'t contain the required numeric characters');
+    expect(errors[0].message).toBe('"value" should contain at least 1 number');
   });
 
   it('should treat a requirement count that is higher than 4 as no requirement count', () => {
     const password = 'Password12';
-    const result = Joi.validate(password, new PasswordComplexity({
+    const result = passwordComplexity({
       min: 8,
       max: 30,
       lowerCase: 1,
@@ -126,8 +127,8 @@ describe('JoiPasswordComplexity', () => {
       numeric: 1,
       symbol: 0,
       requirementCount: 100,
-    }));
+    }).validate(password);
 
-    expect(result.error).toBeNull();
+    expect(result.error).toBeUndefined();
   });
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -139,37 +139,43 @@
     exec-sh "^0.3.2"
     minimist "^1.2.0"
 
-"@hapi/address@2.x.x":
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/@hapi/address/-/address-2.0.0.tgz#9f05469c88cb2fd3dcd624776b54ee95c312126a"
-  integrity sha512-mV6T0IYqb0xL1UALPFplXYQmR0twnXG0M6jUswpquqT2sD12BOiCiLy3EvMp/Fy7s3DZElC4/aPjEjo2jeZpvw==
+"@hapi/address@^2.1.2":
+  version "2.1.2"
+  resolved "https://registry.yarnpkg.com/@hapi/address/-/address-2.1.2.tgz#1c794cd6dbf2354d1eb1ef10e0303f573e1c7222"
+  integrity sha512-O4QDrx+JoGKZc6aN64L04vqa7e41tIiLU+OvKdcYaEMP97UttL0f9GIi9/0A4WAMx0uBd6SidDIhktZhgOcN8Q==
 
-"@hapi/bourne@1.x.x":
-  version "1.3.2"
-  resolved "https://registry.yarnpkg.com/@hapi/bourne/-/bourne-1.3.2.tgz#0a7095adea067243ce3283e1b56b8a8f453b242a"
-  integrity sha512-1dVNHT76Uu5N3eJNTYcvxee+jzX4Z9lfciqRRHCU27ihbUcYi+iSc2iml5Ke1LXe1SyJCLA0+14Jh4tXJgOppA==
+"@hapi/formula@^1.2.0":
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/@hapi/formula/-/formula-1.2.0.tgz#994649c7fea1a90b91a0a1e6d983523f680e10cd"
+  integrity sha512-UFbtbGPjstz0eWHb+ga/GM3Z9EzqKXFWIbSOFURU0A/Gku0Bky4bCk9/h//K2Xr3IrCfjFNhMm4jyZ5dbCewGA==
 
-"@hapi/hoek@8.x.x":
-  version "8.2.1"
-  resolved "https://registry.yarnpkg.com/@hapi/hoek/-/hoek-8.2.1.tgz#924af04cbb22e17359c620d2a9c946e63f58eb77"
-  integrity sha512-JPiBy+oSmsq3St7XlipfN5pNA6bDJ1kpa73PrK/zR29CVClDVqy04AanM/M/qx5bSF+I61DdCfAvRrujau+zRg==
+"@hapi/hoek@^8.2.4", "@hapi/hoek@^8.3.0":
+  version "8.5.0"
+  resolved "https://registry.yarnpkg.com/@hapi/hoek/-/hoek-8.5.0.tgz#2f9ce301c8898e1c3248b0a8564696b24d1a9a5a"
+  integrity sha512-7XYT10CZfPsH7j9F1Jmg1+d0ezOux2oM2GfArAzLwWe4mE2Dr3hVjsAL6+TFY49RRJlCdJDMw3nJsLFroTc8Kw==
 
-"@hapi/joi@^15.1.1":
-  version "15.1.1"
-  resolved "https://registry.yarnpkg.com/@hapi/joi/-/joi-15.1.1.tgz#c675b8a71296f02833f8d6d243b34c57b8ce19d7"
-  integrity sha512-entf8ZMOK8sc+8YfeOlM8pCfg3b5+WZIKBfUaaJT8UsjAAPjartzxIYm3TIbjvA4u+u++KbcXD38k682nVHDAQ==
+"@hapi/joi@^16.1.7":
+  version "16.1.7"
+  resolved "https://registry.yarnpkg.com/@hapi/joi/-/joi-16.1.7.tgz#360857223a87bb1f5f67691537964c1b4908ed93"
+  integrity sha512-anaIgnZhNooG3LJLrTFzgGALTiO97zRA1UkvQHm9KxxoSiIzCozB3RCNCpDnfhTJD72QlrHA8nwGmNgpFFCIeg==
   dependencies:
-    "@hapi/address" "2.x.x"
-    "@hapi/bourne" "1.x.x"
-    "@hapi/hoek" "8.x.x"
-    "@hapi/topo" "3.x.x"
+    "@hapi/address" "^2.1.2"
+    "@hapi/formula" "^1.2.0"
+    "@hapi/hoek" "^8.2.4"
+    "@hapi/pinpoint" "^1.0.2"
+    "@hapi/topo" "^3.1.3"
 
-"@hapi/topo@3.x.x":
-  version "3.1.3"
-  resolved "https://registry.yarnpkg.com/@hapi/topo/-/topo-3.1.3.tgz#c7a02e0d936596d29f184e6d7fdc07e8b5efce11"
-  integrity sha512-JmS9/vQK6dcUYn7wc2YZTqzIKubAQcJKu2KCKAru6es482U5RT5fP1EXCPtlXpiK7PR0On/kpQKI4fRKkzpZBQ==
+"@hapi/pinpoint@^1.0.2":
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/@hapi/pinpoint/-/pinpoint-1.0.2.tgz#025b7a36dbbf4d35bf1acd071c26b20ef41e0d13"
+  integrity sha512-dtXC/WkZBfC5vxscazuiJ6iq4j9oNx1SHknmIr8hofarpKUZKmlUVYVIhNVzIEgK5Wrc4GMHL5lZtt1uS2flmQ==
+
+"@hapi/topo@^3.1.3":
+  version "3.1.6"
+  resolved "https://registry.yarnpkg.com/@hapi/topo/-/topo-3.1.6.tgz#68d935fa3eae7fdd5ab0d7f953f3205d8b2bfc29"
+  integrity sha512-tAag0jEcjwH+P2quUfipd7liWCNX2F8NvYjQp2wtInsZxnMlypdw0FtAOLxtvvkO+GSRRbmNi8m/5y42PQJYCQ==
   dependencies:
-    "@hapi/hoek" "8.x.x"
+    "@hapi/hoek" "^8.3.0"
 
 "@jest/console@^24.7.1", "@jest/console@^24.9.0":
   version "24.9.0"


### PR DESCRIPTION
Hey @kamronbatman :) `@hapi/joi` released [new major version with lots of breaking changes](https://github.com/hapijs/joi/issues/2037), and unfortunately, the current version of `joi-password-complexity` isn't compatible with `Joi@16` anymore. This PR target this issue.

I've updated `@hapi/joi` dependency, used new `extend()` API instead of going into the internals of Joi to extend from Any. I also added new formatted error messages with pluralized option values. Tests are updated.