### PR TITLE
Add Custom Error Label

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,6 @@ passwordComplexity().validate('aPassword123!');
 ```
 
 When no options are specified, the following are used:
-
 ```javascript
 {
   min: 8,

--- a/README.md
+++ b/README.md
@@ -57,16 +57,6 @@ passwordComplexity(complexityOptions).validate('aPassword123!');
 ```javascript
 const passwordComplexity = require('joi-password-complexity');
 
-const complexityOptions = {
-  min: 10,
-  max: 30,
-  lowerCase: 1,
-  upperCase: 1,
-  numeric: 1,
-  symbol: 1,
-  requirementCount: 2
-};
-
 passwordComplexity(undefined, 'Password').validate('aPassword123!');
 ```
 

--- a/README.md
+++ b/README.md
@@ -3,7 +3,6 @@
 Creates a Joi object that validates password complexity.
 
 ## Requirements
-
 - Joi v16 or higher
 - Nodejs 10 or higher
 
@@ -46,8 +45,8 @@ const complexityOptions = {
   upperCase: 1,
   numeric: 1,
   symbol: 1,
-  requirementCount: 2
-};
+  requirementCount: 2,
+}
 
 passwordComplexity(complexityOptions).validate('aPassword123!');
 ```

--- a/README.md
+++ b/README.md
@@ -3,8 +3,9 @@
 Creates a Joi object that validates password complexity.
 
 ## Requirements
-* Joi v16 or higher
-* Nodejs 10 or higher
+
+- Joi v16 or higher
+- Nodejs 10 or higher
 
 ## Installation
 
@@ -20,6 +21,7 @@ passwordComplexity().validate('aPassword123!');
 ```
 
 When no options are specified, the following are used:
+
 ```javascript
 {
   min: 8,
@@ -44,11 +46,32 @@ const complexityOptions = {
   upperCase: 1,
   numeric: 1,
   symbol: 1,
-  requirementCount: 2,
-}
+  requirementCount: 2
+};
 
 passwordComplexity(complexityOptions).validate('aPassword123!');
 ```
+
+### Error Label (optional) Specified
+
+```javascript
+const passwordComplexity = require('joi-password-complexity');
+
+const complexityOptions = {
+  min: 10,
+  max: 30,
+  lowerCase: 1,
+  upperCase: 1,
+  numeric: 1,
+  symbol: 1,
+  requirementCount: 2
+};
+
+passwordComplexity(undefined, 'Password').validate('aPassword123!');
+```
+
+The resulting error message:
+'Password should be at least 8 characters long'
 
 ## License
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -21,25 +21,25 @@ module.exports = ({
   numeric,
   symbol,
   requirementCount,
-} = defaultOptions) => {
+} = defaultOptions, label) => {
   const joiPasswordComplexity = {
     type: 'passwordComplexity',
     base: Joi.string(),
     messages: {
       'passwordComplexity.tooShort':
-        `{{#label}} should be at least ${min} ${p('character', min)} long`,
+        `${label || '{{#label}}'} should be at least ${min} ${p('character', min)} long`,
       'passwordComplexity.tooLong':
-        `{{#label}} should not be longer than ${max} ${p('character', max)}`,
+        `${label || '{{#label}}'} should not be longer than ${max} ${p('character', max)}`,
       'passwordComplexity.lowercase':
-        `{{#label}} should contain at least ${lowerCase} lower-cased ${p('letter', lowerCase)}`,
+        `${label || '{{#label}}'} should contain at least ${lowerCase} lower-cased ${p('letter', lowerCase)}`,
       'passwordComplexity.uppercase':
-        `{{#label}} should contain at least ${upperCase} upper-cased ${p('letter', upperCase)}`,
+        `${label || '{{#label}}'} should contain at least ${upperCase} upper-cased ${p('letter', upperCase)}`,
       'passwordComplexity.numeric':
-        `{{#label}} should contain at least ${numeric} ${p('number', numeric)}`,
+        `${label || '{{#label}}'} should contain at least ${numeric} ${p('number', numeric)}`,
       'passwordComplexity.symbol':
-        `{{#label}} should contain at least ${symbol} ${p('symbol', symbol)}`,
+        `${label || '{{#label}}'} should contain at least ${symbol} ${p('symbol', symbol)}`,
       'passwordComplexity.requirementCount':
-        `{{#label}} must meet at least ${requirementCount} of the complexity requirements`,
+        `${label || '{{#label}}'} must meet at least ${requirementCount} of the complexity requirements`,
     },
     validate: (value, helpers) => {
       const errors = [];

--- a/test/password.test.js
+++ b/test/password.test.js
@@ -130,12 +130,11 @@ describe('JoiPasswordComplexity', () => {
     expect(result.error).toBeUndefined();
   });
 
-  it('should display supplied label', () => {
+  it('should display custom error label when supplied', () => {
     const password = '123';
 
     const result = passwordComplexity(undefined, 'Password').validate(password);
     const errors = result.error.details.filter((e) => e.type === 'passwordComplexity.tooShort');
-    expect(errors.length).toBe(1);
     expect(errors[0].message).toBe('Password should be at least 8 characters long');
   });
 });

--- a/test/password.test.js
+++ b/test/password.test.js
@@ -129,4 +129,13 @@ describe('JoiPasswordComplexity', () => {
 
     expect(result.error).toBeUndefined();
   });
+
+  it('should display supplied label', () => {
+    const password = '123';
+
+    const result = passwordComplexity(undefined, 'Password').validate(password);
+    const errors = result.error.details.filter((e) => e.type === 'passwordComplexity.tooShort');
+    expect(errors.length).toBe(1);
+    expect(errors[0].message).toBe('Password should be at least 8 characters long');
+  });
 });


### PR DESCRIPTION
Added the ability to set a custom error label to the error message. (i.e. 'XXXX should be at least 8 characters long'

`passwordComplexity(complexityOptions, 'Password').validate('aPassword123!');`

Added optional string as second variable to avoid any breaking changes and maintain backwards compatibility. 

Updated readme with optional formating. 