### PR TITLE
fix: support sideway joi

### DIFF
--- a/lib/get.joi.js
+++ b/lib/get.joi.js
@@ -1,0 +1,21 @@
+function getJoi() {
+  let Joi;
+
+  try {
+    Joi = require('joi');
+  } catch (ignoreJoiError) {
+    try {
+      Joi = require('@hapi/joi');
+    } catch (ignoreHapiError) {
+      // ignore
+    }
+  }
+
+  if (!Joi) {
+    throw new Error('joi-password-complexity requires either `joi` or `@hapi/joi` to be installed.');
+  }
+
+  return Joi;
+}
+
+module.exports = getJoi;

--- a/lib/get.joi.js
+++ b/lib/get.joi.js
@@ -1,21 +1,20 @@
-function getJoi() {
-  let Joi;
-
+const softRequire = (path) => {
   try {
-    Joi = require('joi');
-  } catch (ignoreJoiError) {
-    try {
-      Joi = require('@hapi/joi');
-    } catch (ignoreHapiError) {
-      // ignore
-    }
+    // eslint-disable-next-line import/no-dynamic-require
+    return require(path);
+  } catch (ignoreError) {
+    return null;
   }
+};
 
-  if (!Joi) {
+const getJoi = () => {
+  const joi = softRequire('joi') || softRequire('@hapi/joi');
+
+  if (!joi) {
     throw new Error('joi-password-complexity requires either `joi` or `@hapi/joi` to be installed.');
   }
 
-  return Joi;
-}
+  return joi;
+};
 
 module.exports = getJoi;

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,4 +1,4 @@
-const Joi = require('@hapi/joi');
+const Joi = require('./get.joi.js')();
 
 // pluralize
 const p = (word, num) => (num === 1 ? word : `${word}s`);

--- a/package.json
+++ b/package.json
@@ -19,7 +19,9 @@
     "eslint-config-airbnb-base": "^14.1.0",
     "eslint-plugin-import": "^2.20.1",
     "eslint-plugin-jest": "^23.8.2",
-    "jest": "^25.1.0"
+    "jest": "^25.1.0",
+    "@hapi/joi": "^17.1.1",
+    "joi": "^17.1.1"
   },
   "engines": {
     "node": ">= 10.0.0"

--- a/package.json
+++ b/package.json
@@ -11,9 +11,6 @@
     "type": "git",
     "url": "git+https://github.com/kamronbatman/joi-password-complexity.git"
   },
-  "peerDependencies": {
-    "@hapi/joi": "^16.0.0 || ^17.0.0 || ^17.1.0"
-  },
   "devDependencies": {
     "eslint": "^6.8.0",
     "eslint-config-airbnb-base": "^14.1.0",


### PR DESCRIPTION
[@hapi/joi is being deprecated, and people should use joi instead.](https://github.com/sideway/joi/issues/2411)

This PR makes this plugin use `joi` by default, if not found, it will use @hapi/joi.