### PR TITLE
Added detailed explanation and example of adding custom error label

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 Creates a Joi object that validates password complexity.
 
 ## Requirements
+
 - Joi v16 or higher
 - Nodejs 10 or higher
 
@@ -15,11 +16,12 @@ Creates a Joi object that validates password complexity.
 ### No options specified
 
 ```javascript
-const passwordComplexity = require('joi-password-complexity');
-passwordComplexity().validate('aPassword123!');
+const passwordComplexity = require("joi-password-complexity");
+passwordComplexity().validate("aPassword123!");
 ```
 
 When no options are specified, the following are used:
+
 ```javascript
 {
   min: 8,
@@ -35,7 +37,7 @@ When no options are specified, the following are used:
 ### Options specified
 
 ```javascript
-const passwordComplexity = require('joi-password-complexity');
+const passwordComplexity = require("joi-password-complexity");
 
 const complexityOptions = {
   min: 10,
@@ -45,17 +47,27 @@ const complexityOptions = {
   numeric: 1,
   symbol: 1,
   requirementCount: 2,
-}
+};
 
-passwordComplexity(complexityOptions).validate('aPassword123!');
+passwordComplexity(complexityOptions).validate("aPassword123!");
 ```
 
 ### Error Label (optional) Specified
 
-```javascript
-const passwordComplexity = require('joi-password-complexity');
+For default options:
 
-passwordComplexity(undefined, 'Password').validate('aPassword123!');
+```javascript
+const passwordComplexity = require("joi-password-complexity");
+
+passwordComplexity(undefined, "Password").validate("aPassword123!");
+```
+
+For specified options:
+
+```javascript
+const passwordComplexity = require("joi-password-complexity");
+
+passwordComplexity(complexityOptions, "Password").validate("aPassword123!");
 ```
 
 The resulting error message:

--- a/README.md
+++ b/README.md
@@ -54,12 +54,15 @@ passwordComplexity(complexityOptions).validate("aPassword123!");
 
 ### Error Label (optional) Specified
 
+```javascript
+const label = "password"
+```
 - For default options:
 
 ```javascript
 const passwordComplexity = require("joi-password-complexity");
 
-passwordComplexity(undefined, "Password").validate("aPassword123!");
+passwordComplexity(undefined, label).validate("aPassword123!");
 ```
 
 - For specified options:
@@ -67,7 +70,7 @@ passwordComplexity(undefined, "Password").validate("aPassword123!");
 ```javascript
 const passwordComplexity = require("joi-password-complexity");
 
-passwordComplexity(complexityOptions, "Password").validate("aPassword123!");
+passwordComplexity(complexityOptions, label).validate("aPassword123!");
 ```
 
 The resulting error message:

--- a/README.md
+++ b/README.md
@@ -56,20 +56,18 @@ passwordComplexity(complexityOptions).validate("aPassword123!");
 
 ```javascript
 const label = "password"
+
+const passwordComplexity = require("joi-password-complexity");
 ```
 - For default options:
 
 ```javascript
-const passwordComplexity = require("joi-password-complexity");
-
 passwordComplexity(undefined, label).validate("aPassword123!");
 ```
 
 - For specified options:
 
 ```javascript
-const passwordComplexity = require("joi-password-complexity");
-
 passwordComplexity(complexityOptions, label).validate("aPassword123!");
 ```
 

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ passwordComplexity(complexityOptions).validate("aPassword123!");
 ### Error Label (optional) Specified
 
 ```javascript
-const label = "password"
+const label = "Password"
 
 const passwordComplexity = require("joi-password-complexity");
 ```

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ passwordComplexity(complexityOptions).validate("aPassword123!");
 
 ### Error Label (optional) Specified
 
-For default options:
+- For default options:
 
 ```javascript
 const passwordComplexity = require("joi-password-complexity");
@@ -62,7 +62,7 @@ const passwordComplexity = require("joi-password-complexity");
 passwordComplexity(undefined, "Password").validate("aPassword123!");
 ```
 
-For specified options:
+- For specified options:
 
 ```javascript
 const passwordComplexity = require("joi-password-complexity");


### PR DESCRIPTION
https://github.com/kamronbatman/joi-password-complexity/issues/23#issuecomment-674364861

- Adjusted README to show how to pass label arg when using default or specified complexity options
- Provided a more detailed example and output