### PR TITLE
Update tsconfig to use CommonJS module

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "joi-password-complexity",
-  "version": "5.0.1",
+  "version": "5.0.2",
   "description": "Joi validation for password complexity requirements.",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -3,11 +3,13 @@
   "version": "5.0.1",
   "description": "Joi validation for password complexity requirements.",
   "main": "lib/index.js",
+  "types": "lib/index.d.ts",
   "scripts": {
     "test": "jest",
     "lint": "eslint src --ext .js,.ts",
     "lint-fix": "yarn lint --fix",
-    "build": "tsc -p tsconfig.json"
+    "build": "tsc -p tsconfig.json",
+    "prepublishOnly": "yarn build"
   },
   "repository": {
     "type": "git",
@@ -37,6 +39,9 @@
     "joi": "^17.3.0",
     "typescript": "^4.0.5"
   },
+  "files": [
+    "lib"
+  ],
   "keywords": [
     "Joi",
     "validation",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -9,7 +9,7 @@
     "allowSyntheticDefaultImports": true,
     "strict": true,
     "forceConsistentCasingInFileNames": true,
-    "module": "esnext",
+    "module": "CommonJS",
     "moduleResolution": "node",
     "resolveJsonModule": true,
     "isolatedModules": true,


### PR DESCRIPTION
Resolves #33 

Changes esnext to commonjs, note the module cant be used in the browser but that was never the case in previous versions.

Also specified to only publish the files in lib folder and added prepublish hook to ensure building the module before publishing.

I tested it in my application to ensure it works.