### PR TITLE
Remove Nodejs version requirement

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,6 @@ Creates a Joi object that validates password complexity.
 ## Requirements
 
 - Joi v17 or higher
-- Nodejs 14 or higher
 
 ## Installation
 

--- a/package.json
+++ b/package.json
@@ -34,9 +34,6 @@
     "joi": "^17.3.0",
     "typescript": "^4.0.5"
   },
-  "engines": {
-    "node": ">= 14.0.0"
-  },
   "keywords": [
     "Joi",
     "validation",


### PR DESCRIPTION
currently, the module shows an warning on installation which is not necessary
```
npm WARN notsup Unsupported engine for joi-password-complexity@5.0.1: wanted: {"node":">= 14.0.0"} (current: {"node":"12.16.1","npm":"6.14.8"})
npm WARN notsup Not compatible with your version of node/npm: joi-password-complexity@5.0.1
```

as far as I can see the module itself has no requirements to have a specific node version, also as a side note joi itself does not require a specific nodejs version